### PR TITLE
Fix model slug & name to GPT 3.5 Turbo

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -161,7 +161,7 @@
                                     <select id="modelSelect" class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:text-sm sm:leading-6" aria-describedby="modelSelectDesc">
                                         <option value="gpt-4o">GPT-4o (Default)</option>
                                         <option value="gpt-4">GPT-4</option>
-                                        <option value="gpt-3.5">GPT-3.5</option>
+                                        <option value="gpt-3.5-turbo">GPT-3.5 Turbo</option>
                                     </select>
                                     <span id="modelSelectDesc" class="sr-only">Select the GPT model to use for translation</span>
                                 </dd>


### PR DESCRIPTION
The code is calling a model that doesn't exist, this PR fixes this issue by renaming the model and its slug. This is based on the official list of models available here: https://platform.openai.com/docs/models